### PR TITLE
Key was incorrectly being parsed if servers names had different lengths

### DIFF
--- a/RedisCachingProvider/RedisCachingProvider.cs
+++ b/RedisCachingProvider/RedisCachingProvider.cs
@@ -72,7 +72,12 @@ namespace DotNetNuke.Providers.RedisCachingProvider
 				    if (redisValue.ToString().Length > InstanceUniqueId.Length &&
 				        !redisValue.ToString().StartsWith(InstanceUniqueId))
 				    {
-						instance.Remove(redisValue.ToString().Substring(InstanceUniqueId.Length + 1), false);                     
+
+                        int at = redisValue.ToString().IndexOf(":");
+                        if (at != -1)
+                        {
+                            instance.Remove(redisValue.ToString().Substring(at + 1), false);
+                        }
 				    }
 
 				}
@@ -247,7 +252,7 @@ namespace DotNetNuke.Providers.RedisCachingProvider
 
                     Shared.Logger.Info($"{InstanceUniqueId} - Telling other partners to remove cache key {key}...");                    
 					// Notify the channel
-					RedisCache.Publish(new RedisChannel(KeyPrefix + "Redis.Remove", RedisChannel.PatternMode.Auto), $"{InstanceUniqueId}_{key}");
+					RedisCache.Publish(new RedisChannel(KeyPrefix + "Redis.Remove", RedisChannel.PatternMode.Auto), $"{InstanceUniqueId}:{key}");
 				}
 			}
 			catch (Exception e)


### PR DESCRIPTION
Old code assumed InstanceUniqueId was the same length between servers.  If they had different length names, it would incorrectly parse the key value.

I changed the instance/key separate from _ to : for easier parsing
