### PR TITLE
Fixed a problem parsing redis message when keyPrefix includes :

### DIFF
--- a/RedisCachingProvider/RedisCachingProvider.cs
+++ b/RedisCachingProvider/RedisCachingProvider.cs
@@ -62,9 +62,11 @@ namespace DotNetNuke.Providers.RedisCachingProvider
 				if (redisChannel == KeyPrefix + "Redis.Clear")
 				{
 				    var values = redisValue.ToString().Split(':');
-					if (values.Length == 3 && values[0] != InstanceUniqueId) // Avoid to clear twice
+					if (values.Length >= 3 && !redisValue.ToString().StartsWith(InstanceUniqueId)) // Avoid to clear twice
 					{
-						instance.Clear(values[1], values[2], false);                        
+						var type = values[values.Length - 2];
+						var data = values[values.Length - 1];
+						instance.Clear(type, data, false);
 					}
 				}
 				else

--- a/RedisUnitTests/App.config
+++ b/RedisUnitTests/App.config
@@ -21,7 +21,7 @@
     <caching defaultProvider="RedisCachingProvider">
       <providers>
         <clear />
-        <add name="RedisCachingProvider" type="DotNetNuke.Providers.RedisCachingProvider.RedisCachingProvider, DotNetNuke.Providers.RedisCachingProvider" providerPath="~\Providers\CachingProviders\RedisCachingProvider\" silentMode="false" />
+        <add name="RedisCachingProvider" type="DotNetNuke.Providers.RedisCachingProvider.RedisCachingProvider, DotNetNuke.Providers.RedisCachingProvider" providerPath="~\Providers\CachingProviders\RedisCachingProvider\" keyPrefix="DNNCache:" silentMode="false" />
       </providers>
     </caching>
   </dotnetnuke>


### PR DESCRIPTION
In a webfarm, the pubsub mechanism ensures cache is cleared on each node in the
farm. If keyPrefix configuration options includes a ':', a bug in the parsing
means the cache will never be cleared on the other machines.

The fix involves a change to how the instanceUniqueId, type and data are parsed
out of the message.  The last two entries are always considered to be the type
and data, respectively and the instanceUniqueId check changes to be the start
of the message.

Fixes #17