### PR TITLE
Rediscluster

### DIFF
--- a/RedisCachingProvider/RedisCachingProvider.csproj
+++ b/RedisCachingProvider/RedisCachingProvider.csproj
@@ -47,8 +47,8 @@
       <HintPath>..\packages\DotNetNuke.Core.8.0.0.809\lib\net40\Microsoft.ApplicationBlocks.Data.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="StackExchange.Redis, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\StackExchange.Redis.1.1.603\lib\net45\StackExchange.Redis.dll</HintPath>
+    <Reference Include="StackExchange.Redis, Version=1.2.3.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\StackExchange.Redis.1.2.3\lib\net45\StackExchange.Redis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/RedisCachingProvider/Shared.cs
+++ b/RedisCachingProvider/Shared.cs
@@ -116,11 +116,14 @@ namespace DotNetNuke.Providers.RedisCachingProvider
         {
             // Run Lua script to clear cache on Redis server.
             // Lua script cannot unpack large list, so it have to unpack not over 1000 keys per a loop
-            var script = "local keys = redis.call('keys', '" + cacheKeyPattern + "') " +
-                         "if keys and #keys > 0 then " +
-                         "for i=1,#keys,1000 do redis.call('del', unpack(keys, i, math.min(i+999, #keys))) end return #keys " +
-                         "else return 0 end";
-            var result = redisCache.ScriptEvaluate(script);
+            var script = "local keys = redis.call('keys', ARGV[1]) " +
+                            "if keys and #keys > 0 then " +
+                            "for i=1,#keys,1000 do " +
+                            "local rkey = unpack(keys, i, math.min(i+999, #keys)) " +
+                            "redis.call('del', rkey) end return #keys " +
+                            "else return 0 end";
+
+            var result = redisCache.ScriptEvaluate(script, null, new RedisValue[] { cacheKeyPattern });
         }
 
         internal static bool ProcessException(string providerName, Exception e, string key = "", object value = null)

--- a/RedisCachingProvider/packages.config
+++ b/RedisCachingProvider/packages.config
@@ -3,5 +3,5 @@
   <package id="DotNetNuke.Core" version="8.0.0.809" targetFramework="net40" />
   <package id="DotNetNuke.Instrumentation" version="8.0.0.809" targetFramework="net40" />
   <package id="MSBuildTasks" version="1.5.0.196" targetFramework="net451" developmentDependency="true" />
-  <package id="StackExchange.Redis" version="1.1.603" targetFramework="net451" />
+  <package id="StackExchange.Redis" version="1.2.3" targetFramework="net451" />
 </packages>


### PR DESCRIPTION
Error being presented while connecting to redis clusters:
[ERROR] DotNetNuke.Providers.RedisCachingProvider.RedisCachingProvider - StackExchange.Redis.RedisServerException: ERR Error running script (call to f_7f0f1263d5eda592424f841ce2bfb3c7f10c6542): @user_script:1: @user_script: 1: Lua script attempted to access a non local key in a cluster node

Discussion about the exception with regards to clusters StackExchange/StackExchange.Redis#305

In short, redis.call/del need to be called with arguments that can be forwarded to all systems in the cluster. The use of ARGV and local variables allows this code to properly work on clustered environments.

Also updated to redis 1.2.3, I can pull this out of the PR if required.