### PR TITLE
Fixed: Unescaped HTML elements preventing the Persona Bar controls from being displayed

### DIFF
--- a/RedisCachingProvider/RedisCaching.Web/src/components/App.jsx
+++ b/RedisCachingProvider/RedisCaching.Web/src/components/App.jsx
@@ -231,7 +231,7 @@ class App extends Component {
                             </div>
                         </div>  
                         <p>Finally, you can specify a key prefix to set on all the cached items, 
-                            so you can share the Redis server with other DNN instances. If you don't specify any, a default prefix will be applied.</p>
+                            so you can share the Redis server with other DNN instances. If you do not specify any, a default prefix will be applied.</p>
                         <div className="row-100">
                             <SingleLineInputWithError
                                 withLabel={true}


### PR DESCRIPTION
Removed the contraction in App.jsx because the apostrophe character caused an error (something about unescaped HTML elements) and prevented the Persona Bar controls from being displayed.

I've never contributed to someone else's project before. If I did this wrong, please forgive me. 